### PR TITLE
feat: implement mobile-first optimization for WebVM

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -2,7 +2,7 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, user-scalable=yes" />
 		<title>WebVM - Linux virtualization in WebAssembly</title>
 
 		<meta name="description" content="Linux virtual machine, running in the browser via HTML5/WebAssembly. Networking and graphics supported.">

--- a/src/lib/SideBar.svelte
+++ b/src/lib/SideBar.svelte
@@ -67,7 +67,7 @@
 	export let handleTool;
 </script>
 
-<div class="flex flex-row w-14 h-full bg-neutral-700" >
+<div class="flex flex-row w-14 md:w-14 h-full bg-neutral-700" >
 	<div class="flex flex-col shrink-0 w-14 text-gray-300">
 		{#each icons as i}
 			{#if i}
@@ -84,7 +84,7 @@
 		{/each}
 	</div>
 	<div
-		class="relative flex flex-col gap-5 shrink-0 w-80 h-full z-10 p-2 bg-neutral-600 text-gray-100 opacity-95"
+		class="relative flex flex-col gap-5 shrink-0 w-[calc(100vw-3.5rem)] md:w-80 h-full z-10 p-2 bg-neutral-600 text-gray-100 opacity-95"
 		class:hidden={!activeInfo}
 		on:mouseenter={handleMouseEnterPanel}
 		on:mouseleave={hideInfo}

--- a/src/lib/WebVM.svelte
+++ b/src/lib/WebVM.svelte
@@ -143,8 +143,9 @@
 		var internalMult = 1.0;
 		var displayWidth = display.offsetWidth;
 		var displayHeight = display.offsetHeight;
-		var minWidth = 1024;
-		var minHeight = 768;
+		// Mobile-first: Use adaptive minimums based on screen size
+		var minWidth = Math.min(displayWidth, window.innerWidth < 768 ? displayWidth : 1024);
+		var minHeight = Math.min(displayHeight, window.innerWidth < 768 ? displayHeight : 768);
 		if(displayWidth < minWidth)
 			internalMult = minWidth / displayWidth;
 		if(displayHeight < minHeight)
@@ -367,11 +368,11 @@
 			<slot></slot>
 		</SideBar>
 		{#if configObj.needsDisplay}
-			<div class="absolute top-0 bottom-0 {sideBarPinned ? 'left-[23.5rem]' : 'left-14'} right-0">
+			<div class="absolute top-0 bottom-0 left-0 md:left-14 {sideBarPinned ? 'md:left-80' : ''} right-0">
 				<canvas class="w-full h-full cursor-none" id="display"></canvas>
 			</div>
 		{/if}
-		<div class="absolute top-0 bottom-0 {sideBarPinned ? 'left-[23.5rem]' : 'left-14'} right-0 p-1 scrollbar" id="console">
+		<div class="absolute top-0 bottom-0 left-0 md:left-14 {sideBarPinned ? 'md:left-80' : ''} right-0 p-1 scrollbar" id="console">
 		</div>
 	</div>
 </main>

--- a/src/lib/global.css
+++ b/src/lib/global.css
@@ -17,10 +17,25 @@ html
 	height: 100%;
 }
 
-@media (width <= 850px)
-{
-	html
-	{
-		font-size: calc(100vw / 55);
+/* Mobile-first responsive design */
+@media (max-width: 767px) {
+	html {
+		font-size: calc(100vw / 50);
+	}
+	
+	body {
+		overflow: auto; /* Allow scrolling on mobile if needed */
+	}
+}
+
+@media (min-width: 768px) and (max-width: 1023px) {
+	html {
+		font-size: calc(100vw / 60);
+	}
+}
+
+@media (min-width: 1024px) {
+	html {
+		font-size: 16px; /* Standard desktop size */
 	}
 }


### PR DESCRIPTION
Converts WebVM to mobile-first design, prioritizing mobile experience over desktop.

## Changes:
- Enhanced viewport configuration with viewport-fit=cover
- Replaced fixed 1024x768 minimums with mobile-adaptive sizing
- Converted sidebar to mobile-first design with full-width overlay
- Implemented progressive responsive CSS with mobile/tablet/desktop breakpoints
- Layout system now prioritizes mobile experience

Resolves #1

Generated with [Claude Code](https://claude.ai/code)