### PR TITLE
feat: increase font sizes and constrain terminal width for mobile

### DIFF
--- a/src/lib/WebVM.svelte
+++ b/src/lib/WebVM.svelte
@@ -181,6 +181,20 @@
 	{
 		term.options.fontSize = computeXTermFontSize();
 		fitAddon.fit();
+		
+		// Constrain terminal width on mobile devices for better readability
+		if (window.innerWidth <= 767) {
+			// Mobile: limit to 60 characters max
+			if (term.cols > 60) {
+				term.resize(60, term.rows);
+			}
+		} else if (window.innerWidth <= 1023) {
+			// Tablet: limit to 80 characters max  
+			if (term.cols > 80) {
+				term.resize(80, term.rows);
+			}
+		}
+		
 		const display = document.getElementById("display");
 		if(display)
 			setScreenSize(display);

--- a/src/lib/global.css
+++ b/src/lib/global.css
@@ -17,10 +17,10 @@ html
 	height: 100%;
 }
 
-/* Mobile-first responsive design */
+/* Mobile-first responsive design - Larger fonts for better readability */
 @media (max-width: 767px) {
 	html {
-		font-size: calc(100vw / 50);
+		font-size: calc(100vw / 35); /* Increased from /50 for larger mobile font */
 	}
 	
 	body {
@@ -30,12 +30,12 @@ html
 
 @media (min-width: 768px) and (max-width: 1023px) {
 	html {
-		font-size: calc(100vw / 60);
+		font-size: calc(100vw / 45); /* Increased from /60 for larger tablet font */
 	}
 }
 
 @media (min-width: 1024px) {
 	html {
-		font-size: 16px; /* Standard desktop size */
+		font-size: 18px; /* Increased from 16px for better desktop readability */
 	}
 }


### PR DESCRIPTION
Increases font sizes significantly and adds terminal width constraints for better mobile experience.

## Changes:
- Mobile: ~43% larger fonts (calc(100vw/35) vs /50)
- Tablet: ~33% larger fonts (calc(100vw/45) vs /60)
- Desktop: 12.5% larger fonts (18px vs 16px)
- Mobile terminal: max 60 characters width
- Tablet terminal: max 80 characters width

Resolves #1

🚀 Generated with [Claude Code](https://claude.ai/code)